### PR TITLE
shrubbery doesn't use | as a matched delimiter

### DIFF
--- a/shrubbery/indentation.rkt
+++ b/shrubbery/indentation.rkt
@@ -16,7 +16,8 @@
 
 (provide shrubbery-indentation
          shrubbery-range-indentation
-         shrubbery-paren-matches)
+         shrubbery-paren-matches
+         shrubbery-quote-matches)
 
 (define NORMAL-INDENT 2)
 (define BAR-INDENT 0)

--- a/shrubbery/main.rkt
+++ b/shrubbery/main.rkt
@@ -36,6 +36,9 @@
       [(drracket:paren-matches)
        (dynamic-require 'shrubbery/indentation
                         'shrubbery-paren-matches)]
+      [(drracket:quote-matches)
+       (dynamic-require 'shrubbery/indentation
+                        'shrubbery-quote-matches)]
       [(drracket:grouping-position)
        (dynamic-require 'shrubbery/navigation
                         'shrubbery-grouping-position)]

--- a/shrubbery/private/paren.rkt
+++ b/shrubbery/private/paren.rkt
@@ -1,9 +1,13 @@
 #lang racket/base
 
-(provide shrubbery-paren-matches)
+(provide shrubbery-paren-matches
+         shrubbery-quote-matches)
 
 (define shrubbery-paren-matches
   '((|(| |)|)
     (|[| |]|)
     (|{| |}|)
     (« »)))
+
+(define shrubbery-quote-matches
+  '(#\"))


### PR DESCRIPTION
This should make it so, when "Enable automatic parentheses...." is turned on, typing `"` results in `""` but typing `|` results only in `|`. 

This requires [recent](https://github.com/racket/gui/commit/416b6a4b581189c6307604f957b9e85593767edf) [commits](https://github.com/racket/drracket/commit/2e493578852ee6f7da72e4594b9a1fc601175680) in gui and drracket to work properly (everything still builds without both of them but it doesn't actually work).