### PR TITLE
Initial implementation of Scala-style implicit functions.

### DIFF
--- a/rhombus/private/underscore.rkt
+++ b/rhombus/private/underscore.rkt
@@ -3,7 +3,8 @@
                      syntax/parse)
          "expression.rkt"
          "binding.rkt"
-         "expression+binding.rkt")
+         "expression+binding.rkt"
+         "parse.rkt")
 
 (provide (rename-out [rhombus-_ _]))
 
@@ -15,6 +16,12 @@
    ;; expression
    (lambda (stx)
      (syntax-parse stx
+       #:datum-literals (op)
+       [(form-id . tail)
+        (values
+         #`(lambda (x) (rhombus-expression (group x . tail)))
+         #'())
+        ]
        [(form-id . tail)
         (raise-syntax-error #f
                             (string-append "not allowed as an expression;\n"


### PR DESCRIPTION
Following the style of the `fancy-app` package. Does not handle
operators yet, nor does it handle `.`.

This makes `f(_,1)` expand to `fun(x): f(x,1)`.

Main design question is the behavior of multiple _ in the application.
This PR causes each _ to become a distinct function argument, in
order of their appearance. Alternative designs:
 - multiple _ all become the same binding
 - multiple _ are illegal